### PR TITLE
Drop Linux from test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-15-intel, macos-26 ]
+        os: [ macos-15-intel, macos-26 ]
     runs-on: ${{ matrix.os }}
     permissions:
       actions: read


### PR DESCRIPTION
The tap only ships macOS targets (peel cask + gitalong formula are both macOS-only). Linux test runs add no signal and currently fail on the gitalong PR because precompiled glibc binaries don't survive linuxbrew's linkage check.