### PR TITLE
Bump tap CI to ubuntu-24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-15-intel, macos-26 ]
+        os: [ ubuntu-24.04, macos-15-intel, macos-26 ]
     runs-on: ${{ matrix.os }}
     permissions:
       actions: read


### PR DESCRIPTION
Homebrew now requires a newer glibc than Ubuntu 22.04 ships, breaking `brew doctor` in `test-bot --only-setup` (e.g. PR #14). Bump the matrix runner to ubuntu-24.04 (glibc 2.39).