### PR TITLE
trotter 0.2.0

### DIFF
--- a/Casks/t/trotter.rb
+++ b/Casks/t/trotter.rb
@@ -1,12 +1,11 @@
 cask "trotter" do
-  version "0.1.0"
-  sha256 "df67f48c59fcd8952892910b0bd8ddc34d7a8973e7e666434e5f1fcdb715bd72"
+  version "0.2.0"
+  sha256 "ae1c4db518f66bd6af25c45e937ea45a001d0df72c9571c56299df468bb73b20"
 
-  url "https://api.douglaslassance.me/trotter/download/#{version}/aarch64-apple-darwin",
-      verified: "api.douglaslassance.me/trotter/"
+  url "https://api.douglaslassance.me/trotter/download/#{version}/aarch64-apple-darwin"
   name "Trotter"
   desc "Trip mapping"
-  homepage "https://github.com/douglaslassance/trotter"
+  homepage "https://douglaslassance.me/trotter"
 
   livecheck do
     url "https://api.douglaslassance.me/trotter"


### PR DESCRIPTION
Updates trotter to version 0.2.0.

- URL: https://api.douglaslassance.me/trotter/download/0.2.0/aarch64-apple-darwin
- SHA256: ae1c4db518f66bd6af25c45e937ea45a001d0df72c9571c56299df468bb73b20